### PR TITLE
Update guides/traffic_management/listener_configuration/_index.md

### DIFF
--- a/docs/content/guides/traffic_management/listener_configuration/_index.md
+++ b/docs/content/guides/traffic_management/listener_configuration/_index.md
@@ -20,7 +20,7 @@ gloo-system   gateway-proxy       2d
 gloo-system   gateway-proxy-ssl   2d
 ```
 
-`kubectl edit gateway -n gloo-system gateway`
+`kubectl edit gateway -n gloo-system gateway-proxy`
 
 ### Plugin summary
 
@@ -33,11 +33,12 @@ metadata: # collapsed for brevity
 spec:
   bindAddress: '::'
   bindPort: 8080
-  options:
-    grpcWeb:
-      disable: true
-    httpConnectionManagerSettings:
-      via: reference-string
+  httpGateway:
+    options:
+      grpcWeb:
+        disable: true
+      httpConnectionManagerSettings:
+        via: reference-string
   useProxyProto: false
 status: # collapsed for brevity
 {{< /highlight >}}


### PR DESCRIPTION
# Description

This bug fixes **Listener Configuration** guide documentation. More specifically, it fixes typos on the https://docs.solo.io/gloo/latest/guides/traffic_management/listener_configuration/ page.

# Context

I was working my way through the _latest_ [Listener Configuration](https://docs.solo.io/gloo/latest/guides/traffic_management/listener_configuration/) guide and encountered the typo.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works